### PR TITLE
Travis CI integration for the impact search repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+node_js:
+  - 0.12
+
+before_install:
+  - npm install -g webpack-dev-server
+  - npm install -g bower
+  - npm install -g tsd
+  - ./setup.sh
+
+script: make local
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Impact Search
 
+[![Build Status](https://travis-ci.org/impact/search.svg)](https://travis-ci.org/impact/search)
+
 This is a simple web application built using
 [React](http://reactjs.com) and
 [TypeScript](http://www.typescriptlang.org/).  It uses an index file

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+ISERROR=0
+
+which npm > /dev/null 2>&1
+if [ $? -ne 0 ] ; then
+	echo "command not found: npm"
+	echo "please install npm. e.g. sudo apt-get install npm"
+	ISERROR=1
+fi
+
+which bower > /dev/null 2>&1
+if [ $? -ne 0 ] ; then
+	echo "command not found: bower"
+	echo "please install grunt. e.g. npm install -g bower"
+	ISERROR=1
+fi
+
+which tsd > /dev/null 2>&1
+if [ $? -ne 0 ] ; then
+	echo "command not found: webpack-dev-server"
+	echo "please install grunt. e.g. npm install -g tsd"
+	ISERROR=1
+fi
+
+which webpack-dev-server > /dev/null 2>&1
+if [ $? -ne 0 ] ; then
+	echo "command not found: webpack-dev-server"
+	echo "please install grunt. e.g. npm install -g webpack-dev-server"
+	ISERROR=1
+fi
+
+if [ $ISERROR -ne 0 ] ; then
+	exit
+fi
+
+rm -rf .sass-cache bower_components bower-task node_modules tsd-cache && \
+bower install && \
+npm install && \
+tsd reinstall && \
+echo "Dependencies OK!"


### PR DESCRIPTION
Added travis CI integration for the impact repository.

To enable the build, the project admin should:
* go to [https://travis-ci.org/](https://travis-ci.org/)
* enable the search repository under "My Repositories" (press the plus sign)
* the admin might have to add the Github OAuth token as environmental variable TSD_GITHUB_TOKEN (under "Homepage -> impact/search -> Settings -> Settings"), to prevent Github rate limitation